### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This package is for working with cubic Bezier curves and is specifically made as a dependency for [Elm Animator](https://package.elm-lang.org/packages/mdgriffith/elm-animator/1.1.1/).
 
-A good amount of this code was borrowed from [Elm Geometry](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry), though the `Bezier.Spring` module is largely unique (though it was written with a considerable amount of help from Ian Mackenzie, for which I have very grateful!)
+A good amount of this code was borrowed from [Elm Geometry](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry), though the `Bezier.Spring` module is largely unique (though it was written with a considerable amount of help from Ian Mackenzie, for which I am very grateful!)

--- a/src/Bezier.elm
+++ b/src/Bezier.elm
@@ -11,9 +11,9 @@ module Bezier exposing
     , toPath, toCss
     )
 
-{-| Bézier(pronounced bez-E-ey) curves are super cool and commonly used in animation!
+{-| Bézier (pronounced bez-E-ey) curves are super cool and commonly used in animation!
 
-[Here is an excellent video on them.](https://www.youtube.com/watch?v=aVwxzDHniEw).
+[Here is an excellent video on them](https://www.youtube.com/watch?v=aVwxzDHniEw).
 
 This module borrows a lot of code from [Elm Geometry](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry), but is much more focused on animation needs for [Elm Animator](https://package.elm-lang.org/packages/mdgriffith/elm-animator).
 

--- a/src/Bezier/Spring.elm
+++ b/src/Bezier/Spring.elm
@@ -540,14 +540,12 @@ toleranceForSpringSettleTimeCalculation =
     -1 * logBase e 0.005
 
 
-{-|
+{-| We can detect when a spring will settle if it is underdamped (meaning it oscillates before resting).
+<https://en.wikipedia.org/wiki/Settling_time>
 
-    We can detect when a spring will settle if it is underdamped (meaning it oscillates before resting)
-    <https://en.wikipedia.org/wiki/Settling_time>
-
-    However for critcally and overdamped systems it gets a lot more complicated.
-    Fortunately, I'm not sure that that's an issue as I don't think we want to model overdamped spring systems for animation.
-    https://electronics.stackexchange.com/questions/296567/over-and-critically-damped-systems-settling-time
+However for critically and overdamped systems it gets a lot more complicated.
+Fortunately, I'm not sure that that's an issue as I don't think we want to model overdamped spring systems for animation.
+<https://electronics.stackexchange.com/questions/296567/over-and-critically-damped-systems-settling-time>
 
 -}
 settlesAt : Parameters -> Float


### PR DESCRIPTION
The documentation for https://package.elm-lang.org/packages/mdgriffith/elm-bezier/1.0.0/Bezier-Spring#stepOver also looks weird, I think some words are missing on the last line, but I don't know how to fix it.